### PR TITLE
GCAdapter: Use correct controller origin

### DIFF
--- a/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
+++ b/Source/Core/Core/HW/SI/SI_DeviceGCAdapter.cpp
@@ -43,7 +43,7 @@ GCPadStatus CSIDevice_GCAdapter::GetPadStatus()
   // Our GCAdapter code sets PAD_GET_ORIGIN when a new device has been connected.
   // Watch for this to calibrate real controllers on connection.
   if (pad_status.button & PAD_GET_ORIGIN)
-    SetOrigin(pad_status);
+    SetOrigin(GCAdapter::Origin(m_device_number));
 
   return pad_status;
 }

--- a/Source/Core/InputCommon/GCAdapter.h
+++ b/Source/Core/InputCommon/GCAdapter.h
@@ -17,6 +17,7 @@ void Shutdown();
 void SetAdapterCallback(std::function<void(void)> func);
 void StartScanThread();
 void StopScanThread();
+GCPadStatus Origin(int chan);
 GCPadStatus Input(int chan);
 void Output(int chan, u8 rumble_command);
 bool IsDetected(const char** error_message);


### PR DESCRIPTION
A real console sends an "origin" (0x41) SI command when requesting the controller's origin. Currently, Dolphin uses the result of the first "status" command (0x40) as the controller's origin. This causes controllers that expect the origin to be whatever was queried by the origin command to behave differently on Dolphin compared to console.

The current GC adapter code only utilizes a subset of its functionality. It enables polling (write 0x13 to out-endpoint), reads status data (read in-endpoint), and writes rumble data (write 0x11 to out-endpoint). This PR adds the "origin" functionality (write 0x12 to out-endpoint). From my testing, in order to use the "origin" command reliably you must first stop polling the controller (write 0x14 to out-endpoint), read the result of that operation, issue the "origin" command (write 0x12 to out-endpoint), read the result, then resume polling (write 0x13 to out-endpoint).

I haven't seen anyone else document the GC adapter's state machine, so I'll do so here to explain the code changes.
- When adapter is initially powered on, it does not communicate with the controllers.
- Once a "start polling" (0x13) command is issued, the adapter will send a ID (0x00) SI command to the controllers then repeatedly send the "origin" (0x41) SI command to the controller.
- Once controller status has been read from the adapter (read to in-endpoint) at least one time, the adapter will stop repeatedly sending the "origin" (0x41) SI command and start repeatedly sending the "status" (0x40) SI command.
  - (Also worth noting: if a controller is hot-plugged, it is put into the "repeated origin" state until controller status has been read from the adapter, even if a status read has already been issued).
- Once controllers are in the "status" command state, the only way (that I've found) to put them back into the "repeated origin" state is to issue the "hard reset" (write 0x15 to out-endpoint) command to the adapter.

In summary, this PR seeks to do the following:
- Put controllers into "repeated origin" state until a game is started.
- Read origins from the adapter's "origin" command instead of the "status" command